### PR TITLE
feat: Add core screenshot automation bot

### DIFF
--- a/Python/screenshot_automation_bot/README.MD
+++ b/Python/screenshot_automation_bot/README.MD
@@ -1,0 +1,75 @@
+````markdown
+# 📸 Screenshot Automation Bot
+
+`screenshot_automation_bot.py` is a Python CLI tool that **automates taking periodic full-page screenshots** of any website using [Playwright](https://playwright.dev/).
+
+Ideal for monitoring visual changes, archiving web content, or debugging dynamic pages over time.
+
+---
+
+## 🚀 How to Run
+
+After installing the required dependencies (see below), run the script as follows:
+
+```bash
+python screenshot_automation_bot.py <url> [options]
+````
+
+### ⚙️ Command-Line Options
+
+| Option | Description | Default |
+| :--- | :--- | :--- |
+| `<url>` | (Required) The target website URL to screenshot | `None` |
+| `-i`, `--interval` | Interval (in seconds) between each screenshot | `300` (5 minutes) |
+| `-o`, `--output` | Output directory to save screenshots | `output/` |
+| `--headless` | Run the browser in headless mode (no GUI) | `False` (GUI is shown by default) |
+
+### 📂 Example Usage
+
+1.  **Basic example (every 5 minutes):**
+
+    ```bash
+    python screenshot_automation_bot.py [https://example.com](https://example.com)
+    ```
+
+2.  **Custom interval and output directory:**
+
+    ```bash
+    python screenshot_automation_bot.py [https://example.com](https://example.com) -i 600 -o snapshots
+    ```
+
+3.  **Run in headless mode:**
+
+    ```bash
+    python screenshot_automation_bot.py [https://example.com](https://example.com) --headless
+    ```
+
+## 🖼 Output
+
+Screenshots are saved in the specified output folder using a timestamped filename format:
+
+```
+output/
+├── screenshot_20251009_141500.png
+├── screenshot_20251009_142000.png
+...
+```
+
+## 🛠 Requirements
+
+  * Python 3.7 or later
+  * Playwright (Python)
+
+### Install Requirements
+
+```bash
+pip install -r requirements.txt
+playwright install
+```
+
+## 🧯 Stop the Script
+
+Use `Ctrl + C` to safely stop the script when running in a terminal.
+
+```
+```

--- a/Python/screenshot_automation_bot/requirements.txt
+++ b/Python/screenshot_automation_bot/requirements.txt
@@ -1,0 +1,1 @@
+playwright

--- a/Python/screenshot_automation_bot/screenshot_automation_bot.py
+++ b/Python/screenshot_automation_bot/screenshot_automation_bot.py
@@ -1,0 +1,48 @@
+import asyncio
+import os
+from datetime import datetime
+import argparse
+from playwright.async_api import async_playwright
+
+async def take_screenshot(browser, url, output_dir, count):
+    context = await browser.new_context()
+    page = await context.new_page()
+    await page.goto(url)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"screenshot_{timestamp}.png"
+    filepath = os.path.join(output_dir, filename)
+
+    await page.screenshot(path=filepath, full_page=True)
+    print(f"[{count}] Saved screenshot: {filepath}")
+
+    await context.close()
+
+async def main():
+    parser = argparse.ArgumentParser(description="Periodic Website Screenshot Tool using Playwright")
+    parser.add_argument("url", help="Website URL to take screenshots of")
+    parser.add_argument("-i", "--interval", type=int, default=300, help="Interval between screenshots in seconds (default: 300)")
+    parser.add_argument("-o", "--output", default="output", help="Directory to save screenshots (default: ./output)")
+    parser.add_argument("--headless", action="store_true", help="Run browser in headless mode")
+
+    args = parser.parse_args()
+
+    os.makedirs(args.output, exist_ok=True)
+
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch(headless=args.headless)
+
+        count = 1
+        try:
+            while True:
+                await take_screenshot(browser, args.url, args.output, count)
+                count += 1
+                await asyncio.sleep(args.interval)
+        except KeyboardInterrupt:
+            print("Stopped by user.")
+        finally:
+            await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+


### PR DESCRIPTION
This commit introduces the initial version of `screenshot_automation_bot.py`.

It provides a CLI tool using Playwright to:
- Periodically take full-page screenshots of a specified URL.
- Allow configuration of interval, output directory, and headless mode via CLI arguments.
- Save files with a timestamped naming format for easy archiving.

The tool is ideal for visual monitoring and archiving web page changes over time.

Issue #23 

<img width="1920" height="1080" alt="Screenshot From 2025-10-09 00-31-25" src="https://github.com/user-attachments/assets/19aa7576-16e5-4999-bcdf-c495e5cd2064" />
